### PR TITLE
feat: harden tty I/O with typed predicate and fd reuse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+## [0.0.5] - 2025-08-27
+
+### Added
+- add `MorePredicate` type alias and optional `fd` parameter to `read_tty` for reusable TTY access
+
+### Fixed
+- fix `query_tty` to reuse a single TTY file descriptor and close it exactly once
+

--- a/TODO.md
+++ b/TODO.md
@@ -17,12 +17,12 @@
 * [ ] Centralize configuration — Add `wskr.config` module supporting env + kwargs with precedence; surface knobs (timeouts, cache TTLs, fallback behavior, dark-mode policy).
 * [ ] Improve structured logging — Standardize logger names and messages; include key fields (transport, timeout, bytes, img\_id) for Kitty operations; add `logger.debug` on decisions (fallbacks, gates).
 * [ ] Strengthen error messages (style preference) — Assign exception messages to variables before raising (personal style) across the codebase for consistency.
-* [ ] Use type aliases & annotations — Add precise types for callables: e.g., `type MorePredicate = Callable[[bytes], bool]` in `ttyools.py`; annotate public APIs throughout.
+* [x] Use type aliases & annotations — Add precise types for callables: e.g., `type MorePredicate = Callable[[bytes], bool]` in `ttyools.py`; annotate public APIs throughout.
 * [ ] Path handling with `pathlib` — Replace raw string paths with `Path` in `RichImage`, payload scripts, and kitty\_remote helper paths; ensure encoding explicitness when reading files.
 * [ ] Add `__slots__` to high-churn classes — For `RichImage` and lightweight transport helpers to reduce memory overhead during repeated renders.
 * [ ] Avoid global Console — In `src/wskr/rich/img.py`/`plt.py`, avoid module-level `Console()`; take console from Rich call context only to reduce hidden globals.
 * [ ] Document backend selection — README: document Matplotlib backend entry points and how to choose (`MPLBACKEND=wskr_kitty`) plus feature gates; clarify test environment hints.
-* [ ] Harden `tty_attributes` usage — Ensure the fd is captured once, use it consistently, and avoid multiple `os.open()` calls; add tests that assert a single open/close per operation.
+* [x] Harden `tty_attributes` usage — Ensure the fd is captured once, use it consistently, and avoid multiple `os.open()` calls; add tests that assert a single open/close per operation.
 * [ ] Unify PNG rendering path — Deduplicate `_render_to_buffer` in `plt.py` (two versions exist) to a single function; add test that asserts identical bytes for both call sites.
 * [ ] Graceful teardown hooks — Provide `close()`/context manager for transports that may hold resources later; no-op for current transports; add to interface for forward compatibility.
 * [ ] Replace magic numbers — Extract `_IMAGE_CHUNK_SIZE = 4096`, rows=24 heuristic, etc., into `wskr.config` with sensible defaults and docstrings.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 # =================================== project ====================================
 [project]
   name = "wskr"
-  version = "0.0.4"
+  version = "0.0.5"
   description = ""
   readme = "README.md"
   authors = [

--- a/tests/test_tty_extras.py
+++ b/tests/test_tty_extras.py
@@ -54,8 +54,7 @@ def test_query_tty(monkeypatch):
     monkeypatch.setattr(os, "write", lambda fd, data: writes.append((fd, data)))
     monkeypatch.setattr(termios, "tcdrain", lambda fd: None)
     monkeypatch.setattr(os, "close", lambda fd: None)
-    monkeypatch.setattr(ttyools, "tty_attributes", lambda fd, echo=False: contextlib.nullcontext())
-    monkeypatch.setattr(ttyools, "read_tty", lambda timeout=None, more=None: b"resp")
+    monkeypatch.setattr(ttyools, "read_tty", lambda *, fd=None, timeout=None, more=None: b"resp")
     resp = ttyools.query_tty(b"req", more=lambda b: True)
     assert resp == b"resp"
     assert writes == [(55, b"req")]

--- a/tests/test_ttyools.py
+++ b/tests/test_ttyools.py
@@ -34,7 +34,7 @@ def fake_tty(monkeypatch, tmp_path):
     # Monkeypatch tty_attributes to be a simple context
     monkeypatch.setattr(ttyools, "tty_attributes", lambda *args, **kwargs: (yield from []))
     # For select, always say no data
-    monkeypatch.setattr("select.select", lambda r, w, x, t: ([], [], []))
+    monkeypatch.setattr(ttyools, "select", lambda r, w, x, t: ([], [], []))
     return closed
 
 
@@ -48,3 +48,44 @@ def test_read_tty_closes_fd(fake_tty):
     data = ttyools.read_tty(timeout=0, min_bytes=0)
     assert data == b""  # no data read
     assert fake_tty == [99], "read_tty should close its fd"
+
+
+def test_read_tty_more_predicate(monkeypatch):
+    monkeypatch.setattr(ttyools, "_get_tty_fd", lambda: 42)
+    monkeypatch.setattr(os, "close", lambda fd: None)
+    monkeypatch.setattr(ttyools, "tty_attributes", lambda *a, **k: (yield from []))
+    monkeypatch.setattr(ttyools, "select", lambda r, w, x, t: ([], [], []))
+    called = []
+
+    def more(data: bytes) -> bool:
+        called.append(data)
+        return False
+
+    assert ttyools.read_tty(timeout=1, more=more) == b""
+    assert called == [b""]
+
+
+def test_query_tty_single_fd(monkeypatch, tmp_path):
+    fake_fd = 77
+    opens: list[int] = []
+    closes: list[int] = []
+
+    monkeypatch.setattr(os, "ttyname", lambda fd: str(tmp_path / "tty"))
+    monkeypatch.setattr(os, "open", lambda *a, **k: (opens.append(1), fake_fd)[1])
+    monkeypatch.setattr(os, "close", closes.append)
+    monkeypatch.setattr(os, "write", lambda fd, data: len(data))
+    monkeypatch.setattr(termios, "tcdrain", lambda fd: None)
+
+    called_fd: list[int | None] = []
+
+    def fake_read_tty(*, fd: int | None, **kwargs: object) -> bytes:
+        called_fd.append(fd)
+        return b"resp"
+
+    monkeypatch.setattr(ttyools, "read_tty", fake_read_tty)
+
+    resp = ttyools.query_tty(b"req", more=lambda b: False, timeout=0)
+    assert resp == b"resp"
+    assert opens == [1]
+    assert closes == [fake_fd]
+    assert called_fd == [fake_fd]


### PR DESCRIPTION
## Summary
- add `MorePredicate` type alias and allow `read_tty` to accept an existing fd
- fix `query_tty` to reuse a single TTY fd and close it exactly once
- test TTY helpers for predicate behavior and fd lifecycle

## Testing
- `.venv/bin/ruff check src/ tests/`
- `.venv/bin/ty check src/ tests/` *(fails: No such file or directory)*
- `.venv/bin/pytest -k 'not e2e'`
- `.venv/bin/pytest tests/test_e2e_kitty.py`


------
https://chatgpt.com/codex/tasks/task_e_68af3e2b16848327af9ff0f03d37bad0