### PR TITLE
feat: add configurable dark-mode detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## [0.0.9] - 2025-08-27
+
+### Added
+- add dark-mode detection strategies and `wskr.init` hook
+- expose central configuration with environment and runtime overrides
+
+### Changed
+- source kitty timeouts from configuration
+- remove dark-mode styling from backend modules
+
 ## [0.0.8] - 2025-08-27
 
 ### Added

--- a/TODO.md
+++ b/TODO.md
@@ -1,21 +1,21 @@
 # dark mode
 
-* [ ] Configure the default chain order to be Env → OSC
-* [ ] Add a Chain-of-Responsibility in `mpl/utils.py` to try strategies in sequence
-* [ ] Move all `detect_dark_mode()` calls out of the Matplotlib backend modules (`base.py`, `kitty.py`, `sixel.py`, `iterm2.py`)
-* [ ] Move all `plt.style.use("dark_background")` calls out of the backend modules
-* [ ] Introduce a new opt-in startup hook (`wskr.init(style="auto-dark")`) to drive dark-mode styling
-* [ ] Refactor `src/wskr/mpl/utils.py` to support pluggable dark-mode strategies
-* [ ] Implement an `EnvColorStrategy` class for dark-mode detection via environment variables
-* [ ] Implement an `OscQueryStrategy` class for dark-mode detection via OSC 11 queries
+* [x] Configure the default chain order to be Env → OSC
+* [x] Add a Chain-of-Responsibility in `mpl/utils.py` to try strategies in sequence
+* [x] Move all `detect_dark_mode()` calls out of the Matplotlib backend modules (`base.py`, `kitty.py`, `sixel.py`, `iterm2.py`)
+* [x] Move all `plt.style.use("dark_background")` calls out of the backend modules
+* [x] Introduce a new opt-in startup hook (`wskr.init(style="auto-dark")`) to drive dark-mode styling
+* [x] Refactor `src/wskr/mpl/utils.py` to support pluggable dark-mode strategies
+* [x] Implement an `EnvColorStrategy` class for dark-mode detection via environment variables
+* [x] Implement an `OscQueryStrategy` class for dark-mode detection via OSC 11 queries
 
 # configuration
 
-* [ ] Expose a configurable timeout for OSC queries (instead of hard-coded)
-* [ ] Create a new `wskr.config` module to centralize configuration
-* [ ] Support both environment variables and keyword args in `wskr.config`, with defined precedence
-* [ ] Expose knobs via config for timeouts, cache TTLs, fallback behavior, dark-mode policy, etc.
-* [ ] Remove any remaining hard-coded `timeout=1.0` in Kitty transport and source timeouts from `WSKR_TIMEOUT_S` in config
+* [x] Expose a configurable timeout for OSC queries (instead of hard-coded)
+* [x] Create a new `wskr.config` module to centralize configuration
+* [x] Support both environment variables and keyword args in `wskr.config`, with defined precedence
+* [x] Expose knobs via config for timeouts, cache TTLs, fallback behavior, dark-mode policy, etc.
+* [x] Remove any remaining hard-coded `timeout=1.0` in Kitty transport and source timeouts from `WSKR_TIMEOUT_S` in config
 
 # testing
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 # =================================== project ====================================
 [project]
   name = "wskr"
-  version = "0.0.8"
+  version = "0.0.9"
   description = ""
   readme = "README.md"
   authors = [

--- a/src/wskr/__init__.py
+++ b/src/wskr/__init__.py
@@ -1,7 +1,22 @@
 import matplotlib as mpl
+import matplotlib.pyplot as plt
+
+from . import config as _config
 
 # Make *absolutely sure* we never try to invoke TeX during draw or savefig,
 # which would hang under test timeouts.
 mpl.rcParams["text.usetex"] = False
 
-__all__ = []
+
+def init(*, style: str | None = None, **config_overrides: object) -> None:
+    """Initialise wskr and apply optional configuration."""
+    if config_overrides:
+        _config.configure(**config_overrides)
+    if style == "auto-dark":
+        from .mpl.utils import detect_dark_mode  # noqa: PLC0415
+
+        if detect_dark_mode():
+            plt.style.use("dark_background")
+
+
+__all__ = ["init"]

--- a/src/wskr/config.py
+++ b/src/wskr/config.py
@@ -1,23 +1,65 @@
-"""Configuration constants for wskr.
+"""Centralised configuration for :mod:`wskr`.
 
-This module centralizes small tunables that were previously hard coded.
-Values may be overridden with environment variables where noted.
+Environment variables provide the initial values.  Calling :func:`configure`
+at runtime allows tests or applications to override those values with keyword
+arguments which take precedence over the environment and built-in defaults.
 """
 
 from __future__ import annotations
 
 import os
+from typing import Any
 
 # Bytes per chunk when streaming images over the Kitty protocol.
 IMAGE_CHUNK_SIZE: int = 4096
 
-# Typical number of terminal rows; used to subtract the status bar height
-# when computing drawable area.  Terminals are often 24 rows tall.
+# Typical number of terminal rows; used to subtract the status bar height when
+# computing drawable area.  Terminals are often 24 rows tall.
 DEFAULT_TTY_ROWS: int = 24
 
-# Time-to-live for cached window size values in KittyTransport.  Setting the
-# ``WSKR_CACHE_TTL_S`` environment variable allows tests or users to tune this
-# behaviour.
+# Time-to-live for cached window size values in ``KittyTransport``.
 CACHE_TTL_S: float = float(os.getenv("WSKR_CACHE_TTL_S", "1.0"))
 
-__all__ = ["CACHE_TTL_S", "DEFAULT_TTY_ROWS", "IMAGE_CHUNK_SIZE"]
+# Generic timeout for subprocess or TTY operations.
+TIMEOUT_S: float = float(os.getenv("WSKR_TIMEOUT_S", "1.0"))
+
+# Timeout for OSC 11 colour queries.
+OSC_TIMEOUT_S: float = float(os.getenv("WSKR_OSC_TIMEOUT_S", "0.1"))
+
+# Fallback policy when transports are unavailable.
+FALLBACK: str = os.getenv("WSKR_FALLBACK", "noop")
+
+# Dark mode policy override: ``force-on``, ``force-off`` or ``auto``.
+DARK_MODE_POLICY: str = os.getenv("WSKR_DARK_MODE_POLICY", "auto")
+
+
+def configure(**overrides: Any) -> dict[str, Any]:
+    """Override configuration values with keyword arguments.
+
+    Parameters are matched case-insensitively against known configuration
+    fields.  Unknown keys are ignored to keep behaviour predictable.
+    """
+    globals_dict = globals()
+    for key, value in overrides.items():
+        name = key.upper()
+        if name in globals_dict:
+            globals_dict[name] = value
+    return {
+        "CACHE_TTL_S": CACHE_TTL_S,
+        "TIMEOUT_S": TIMEOUT_S,
+        "OSC_TIMEOUT_S": OSC_TIMEOUT_S,
+        "FALLBACK": FALLBACK,
+        "DARK_MODE_POLICY": DARK_MODE_POLICY,
+    }
+
+
+__all__ = [
+    "CACHE_TTL_S",
+    "DARK_MODE_POLICY",
+    "DEFAULT_TTY_ROWS",
+    "FALLBACK",
+    "IMAGE_CHUNK_SIZE",
+    "OSC_TIMEOUT_S",
+    "TIMEOUT_S",
+    "configure",
+]

--- a/src/wskr/mpl/base.py
+++ b/src/wskr/mpl/base.py
@@ -6,22 +6,17 @@ from io import BytesIO
 from typing import Any
 
 import matplotlib as mpl
-import matplotlib.pyplot as plt
 from matplotlib import _api, interactive, is_interactive  # noqa: PLC2701
 from matplotlib._pylab_helpers import Gcf  # noqa: PLC2701
 from matplotlib.backend_bases import FigureManagerBase, _Backend  # noqa: PLC2701
 from matplotlib.backends.backend_agg import FigureCanvasAgg
 
 from wskr.mpl.size import autosize_figure
-from wskr.mpl.utils import detect_dark_mode
 from wskr.tty.base import ImageTransport
 from wskr.tty.registry import get_image_transport
 
 if sys.flags.interactive:
     interactive(b=True)
-
-if detect_dark_mode():
-    plt.style.use("dark_background")
 
 
 def render_figure_to_terminal(canvas: FigureCanvasAgg, transport: ImageTransport) -> None:

--- a/src/wskr/mpl/iterm2.py
+++ b/src/wskr/mpl/iterm2.py
@@ -1,12 +1,10 @@
 import os
 
-import matplotlib.pyplot as plt
 from matplotlib import _api, interactive  # noqa: PLC2701
 from matplotlib.backend_bases import _Backend  # noqa: PLC2701
 from matplotlib.backends.backend_agg import FigureCanvasAgg
 
 from wskr.mpl.base import BaseFigureManager, TerminalBackend
-from wskr.mpl.utils import detect_dark_mode
 
 # TODO: import or implement a ITerm2Transport subclass  # noqa: FIX002, TD002, TD003
 # from wskr.tty.iterm2 import ITerm2Transport
@@ -16,9 +14,6 @@ if os.getenv("WSKR_ENABLE_ITERM2", "false").lower() != "true":
     msg = "iTerm2 backend is not yet implemented. Set WSKR_ENABLE_ITERM2=true to bypass."
     raise ImportError(msg)
 
-
-if detect_dark_mode():
-    plt.style.use("dark_background")
 interactive(True)  # noqa: FBT003
 
 

--- a/src/wskr/mpl/kitty.py
+++ b/src/wskr/mpl/kitty.py
@@ -1,17 +1,11 @@
 import sys
 
-import matplotlib.pyplot as plt
 from matplotlib import _api, interactive  # noqa: PLC2701
 from matplotlib.backend_bases import _Backend  # noqa: PLC2701
 from matplotlib.backends.backend_agg import FigureCanvasAgg
 
 from wskr.mpl.base import BaseFigureManager, TerminalBackend
-from wskr.mpl.utils import detect_dark_mode
 from wskr.tty.kitty import KittyTransport
-
-if detect_dark_mode():
-    plt.style.use("dark_background")
-
 
 if sys.flags.interactive:
     interactive(b=True)

--- a/src/wskr/mpl/sixel.py
+++ b/src/wskr/mpl/sixel.py
@@ -1,6 +1,5 @@
 import os
 
-import matplotlib.pyplot as plt
 from matplotlib import (
     _api,  # noqa: PLC2701
     interactive,
@@ -11,7 +10,6 @@ from matplotlib.backends.backend_agg import FigureCanvasAgg
 from wskr.mpl.base import BaseFigureManager, TerminalBackend
 
 # from wskr.tty.sixel import SixelTransport
-from wskr.mpl.utils import detect_dark_mode
 
 if os.getenv("WSKR_ENABLE_SIXEL", "false").lower() != "true":
     msg = "Sixel backend is not yet implemented. Set WSKR_ENABLE_SIXEL=true to bypass."
@@ -19,9 +17,6 @@ if os.getenv("WSKR_ENABLE_SIXEL", "false").lower() != "true":
 
 # TODO: import or implement a SixelTransport subclass  # noqa: FIX002, TD002, TD003
 # from wskr.tty.sixel import SixelTransport
-
-if detect_dark_mode():
-    plt.style.use("dark_background")
 
 interactive(True)  # noqa: FBT003
 

--- a/src/wskr/mpl/utils.py
+++ b/src/wskr/mpl/utils.py
@@ -1,8 +1,22 @@
+"""Dark mode detection utilities for Matplotlib backends.
+
+The detection logic is implemented as a chain of strategies.  Each strategy
+attempts to determine whether the terminal is using a dark colour scheme.  The
+default order is environment-variable detection followed by an OSC 11 query.
+"""
+
+from __future__ import annotations
+
 import logging
 import os
 import re
+from typing import TYPE_CHECKING, Protocol
 
+from wskr.config import OSC_TIMEOUT_S
 from wskr.ttyools import query_tty
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
 
 logger = logging.getLogger(__name__)
 
@@ -12,53 +26,82 @@ _ENV_BG_THRESHOLD = 8
 _LUMINANCE_THRESHOLD = 0.5
 
 # OSC sequence to query the terminal's background color.
-# We send BEL-terminated “11;?” and expect back e.g.
-#   '\x1b]11;rgb:hhhh/hhhh/hhhh\x07'
-# where each 'hhhh' is a 16-bit hex channel.
 _OSC_BG_QUERY = b"\033]11;?\007"
-_OSC_BG_RESP_RE = re.compile(rb"\]11;rgb:([0-9A-Fa-f]{4})/" rb"([0-9A-Fa-f]{4})/" rb"([0-9A-Fa-f]{4})")
+_OSC_BG_RESP_RE = re.compile(rb"\]11;rgb:([0-9A-Fa-f]{4})/([0-9A-Fa-f]{4})/([0-9A-Fa-f]{4})")
 
 
-def is_dark_mode_env() -> bool:
-    """Detect via $COLORFGBG (e.g. '15;0' for white on black)."""
-    val = os.getenv("COLORFGBG", "")
-    if ";" not in val:
-        msg = "COLORFGBG not set or invalid"
-        raise KeyError(msg)
-    _, bg = val.split(";", 1)
-    return int(bg) < _ENV_BG_THRESHOLD
+class DarkModeStrategy(Protocol):
+    """Protocol for dark-mode detection strategies."""
+
+    def detect(self) -> bool:
+        """Return ``True`` if the strategy determines the background is dark."""
 
 
-def is_dark_mode_osc(timeout: float = 0.1) -> bool:
-    """Query terminal with OSC 11;? BEL → parse 'rgb:xxxx/xxxx/xxxx'."""
-    resp = query_tty(
-        _OSC_BG_QUERY,
-        more=lambda data: not data.endswith(b"\007"),
-        timeout=timeout,
-    )
-    if not resp:
-        msg = "No ANSI background-color response"
-        raise RuntimeError(msg)
-    m = _OSC_BG_RESP_RE.search(resp)
-    if not m:
-        msg = f"Unexpected response: {resp!r}"
-        raise ValueError(msg)
-    # convert from 16-bit hex to float [0.0-1.0]
-    rgb = [int(g, 16) / 0xFFFF for g in m.groups()]
-    # Rec. 709 luminance
-    lum = 0.2126 * rgb[0] + 0.7152 * rgb[1] + 0.0722 * rgb[2]
-    return lum < _LUMINANCE_THRESHOLD
+class EnvColorStrategy:
+    """Detect dark mode using the ``COLORFGBG`` environment variable."""
+
+    def detect(self) -> bool:  # noqa: PLR6301 - simple protocol implementation
+        val = os.getenv("COLORFGBG", "")
+        if ";" not in val:
+            msg = "COLORFGBG not set or invalid"
+            raise KeyError(msg)
+        _, bg = val.split(";", 1)
+        return int(bg) < _ENV_BG_THRESHOLD
 
 
-def detect_dark_mode() -> bool:
-    """Try env-var first, then OSC; default to False (light)."""
+class OscQueryStrategy:
+    """Detect dark mode by querying the terminal via OSC 11."""
+
+    def __init__(self, timeout: float | None = None) -> None:
+        self._timeout = timeout if timeout is not None else OSC_TIMEOUT_S
+
+    def detect(self) -> bool:
+        resp = query_tty(
+            _OSC_BG_QUERY,
+            more=lambda data: not data.endswith(b"\007"),
+            timeout=self._timeout,
+        )
+        if not resp:
+            msg = "No ANSI background-color response"
+            raise RuntimeError(msg)
+        m = _OSC_BG_RESP_RE.search(resp)
+        if not m:
+            msg = f"Unexpected response: {resp!r}"
+            raise ValueError(msg)
+        rgb = [int(g, 16) / 0xFFFF for g in m.groups()]
+        lum = 0.2126 * rgb[0] + 0.7152 * rgb[1] + 0.0722 * rgb[2]
+        return lum < _LUMINANCE_THRESHOLD
+
+
+DEFAULT_STRATEGIES: list[DarkModeStrategy] = [
+    EnvColorStrategy(),
+    OscQueryStrategy(),
+]
+
+
+def detect_dark_mode(
+    strategies: Sequence[DarkModeStrategy] | None = None,
+) -> bool:
+    """Return ``True`` when any strategy reports a dark background.
+
+    ``WSKR_DARK_MODE`` acts as an override.  If unset, the configured
+    strategies are tried in order until one succeeds.
+    """
     override = os.getenv("WSKR_DARK_MODE")
     if override is not None:
         return override.lower() in {"1", "true", "yes", "on"}
-    for fn in (is_dark_mode_env, is_dark_mode_osc):
+    for strat in strategies or DEFAULT_STRATEGIES:
         try:
-            if fn():
+            if strat.detect():
                 return True
         except (KeyError, RuntimeError, ValueError, OSError) as e:
-            logger.debug("%s failed: %s", fn.__name__, e)
+            logger.debug("%s failed: %s", strat.__class__.__name__, e)
     return False
+
+
+__all__ = [
+    "DarkModeStrategy",
+    "EnvColorStrategy",
+    "OscQueryStrategy",
+    "detect_dark_mode",
+]

--- a/src/wskr/tty/kitty.py
+++ b/src/wskr/tty/kitty.py
@@ -4,7 +4,7 @@ import subprocess  # noqa: S404
 import sys
 import time
 
-from wskr.config import CACHE_TTL_S, DEFAULT_TTY_ROWS, IMAGE_CHUNK_SIZE
+from wskr.config import CACHE_TTL_S, DEFAULT_TTY_ROWS, IMAGE_CHUNK_SIZE, TIMEOUT_S
 from wskr.tty.command import CommandRunner
 from wskr.tty.kitty_parser import KittyChunkParser
 from wskr.ttyools import query_tty
@@ -25,7 +25,7 @@ class KittyTransport(ImageTransport):
         self._next_img = 1
         self._cached_size: tuple[int, int] | None = None
         self._cache_time = 0.0
-        self._runner = CommandRunner()
+        self._runner = CommandRunner(timeout=TIMEOUT_S)
 
     def invalidate_cache(self) -> None:
         """Drop any cached window-size information."""
@@ -104,7 +104,7 @@ class KittyTransport(ImageTransport):
         resp = query_tty(
             f"\x1b_Ga=t,q=0,f=32,i={img_num},m=0;\x1b\\".encode(),
             more=lambda b: not b.endswith(b"\x1b\\"),
-            timeout=1.0,
+            timeout=TIMEOUT_S,
         )
         return KittyChunkParser.parse_init_response(img_num, resp)
 

--- a/src/wskr/tty/kitty_remote.py
+++ b/src/wskr/tty/kitty_remote.py
@@ -48,7 +48,8 @@ def run(
 ) -> subprocess.CompletedProcess[Any] | bytes:
     logger.debug("Running: %s", " ".join(cmd))
     if capture_output and not check:
-        return runner.check_output(cmd, **kwargs)
+        kwargs.setdefault("text", False)
+        return cast("bytes", runner.check_output(cmd, **kwargs))
     return runner.run(cmd, capture_output=capture_output, check=check, **kwargs)
 
 

--- a/tests/test_config_module.py
+++ b/tests/test_config_module.py
@@ -1,0 +1,13 @@
+import importlib
+
+import wskr.config as cfg
+
+
+def test_config_env_and_kwargs(monkeypatch):
+    monkeypatch.setenv("WSKR_TIMEOUT_S", "5")
+    importlib.reload(cfg)
+    assert cfg.TIMEOUT_S == 5
+    cfg.configure(timeout_s=2, dark_mode_policy="force-on")
+    assert cfg.TIMEOUT_S == 2
+    assert cfg.DARK_MODE_POLICY == "force-on"
+    cfg.configure(timeout_s=1.0, dark_mode_policy="auto")

--- a/tests/test_dark_mode.py
+++ b/tests/test_dark_mode.py
@@ -1,0 +1,56 @@
+from wskr.mpl import utils
+
+
+def test_env_color_strategy(monkeypatch):
+    monkeypatch.setenv("COLORFGBG", "15;0")
+    assert utils.EnvColorStrategy().detect() is True
+    monkeypatch.setenv("COLORFGBG", "0;15")
+    assert utils.EnvColorStrategy().detect() is False
+    monkeypatch.delenv("COLORFGBG", raising=False)
+    try:
+        utils.EnvColorStrategy().detect()
+    except KeyError:
+        pass
+    else:  # pragma: no cover - fail path
+        raise AssertionError
+
+
+def test_osc_strategy_uses_config_timeout(monkeypatch):
+    monkeypatch.setattr(utils, "OSC_TIMEOUT_S", 0.5)
+    seen: dict[str, float] = {}
+
+    def fake_query(cmd, more, timeout):
+        seen["timeout"] = timeout
+        return b"\x1b]11;rgb:0000/0000/0000\x07"
+
+    monkeypatch.setattr(utils, "query_tty", fake_query)
+    assert utils.OscQueryStrategy().detect() is True
+    assert seen["timeout"] == 0.5
+
+
+def test_detect_dark_mode_chain(monkeypatch):
+    monkeypatch.setenv("COLORFGBG", "15;0")
+    called: dict[str, bool] = {}
+
+    def fake_query(*_a, **_k):
+        called["osc"] = True
+        return b""
+
+    monkeypatch.setattr(utils, "query_tty", fake_query)
+    assert utils.detect_dark_mode() is True
+    assert "osc" not in called
+
+    monkeypatch.delenv("COLORFGBG", raising=False)
+    monkeypatch.setattr(
+        utils,
+        "query_tty",
+        lambda *_a, **_k: b"\x1b]11;rgb:0000/0000/0000\x07",
+    )
+    assert utils.detect_dark_mode() is True
+
+
+def test_detect_dark_mode_override(monkeypatch):
+    monkeypatch.setenv("WSKR_DARK_MODE", "1")
+    assert utils.detect_dark_mode() is True
+    monkeypatch.setenv("WSKR_DARK_MODE", "0")
+    assert utils.detect_dark_mode() is False

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,0 +1,20 @@
+import matplotlib.pyplot as plt
+
+import wskr
+from wskr.mpl import utils
+
+
+def test_init_applies_dark(monkeypatch):
+    monkeypatch.setattr(utils, "detect_dark_mode", lambda: True)
+    seen = {}
+    monkeypatch.setattr(plt.style, "use", lambda style: seen.setdefault("style", style))
+    wskr.init(style="auto-dark")
+    assert seen["style"] == "dark_background"
+
+
+def test_init_no_dark(monkeypatch):
+    monkeypatch.setattr(utils, "detect_dark_mode", lambda: False)
+    seen = {}
+    monkeypatch.setattr(plt.style, "use", lambda style: seen.setdefault("style", style))
+    wskr.init(style="auto-dark")
+    assert seen == {}

--- a/tests/test_tty_kitty.py
+++ b/tests/test_tty_kitty.py
@@ -195,6 +195,20 @@ def test_init_image_bad_response(monkeypatch, dummy_png):
         kt.init_image(dummy_png)
 
 
+def test_init_image_uses_timeout(monkeypatch, dummy_png):
+    sent = {}
+    monkeypatch.setattr(KittyChunkParser, "send_chunk", lambda *a, **k: None)
+
+    def fake_query(cmd, more, timeout):
+        sent["timeout"] = timeout
+        return b"\x1b_Gi=5,i=1;OK\x1b\\"
+
+    monkeypatch.setattr("wskr.tty.kitty.query_tty", fake_query)
+    kt = KittyTransport()
+    kt.init_image(dummy_png)
+    assert sent["timeout"] == cfg.TIMEOUT_S
+
+
 def test_get_window_size_px_cache_ttl(monkeypatch):
     monkeypatch.setenv("WSKR_CACHE_TTL_S", "0")
     importlib.reload(cfg)


### PR DESCRIPTION
## Summary
- add strategy-based dark-mode detection and `wskr.init` hook
- centralize configuration with env/kw overrides and timeouts
- source kitty timeouts from config and remove backend styling

## Testing
- `.venv/bin/ruff check src/ tests/`
- `.venv/bin/ty check src/ tests/`
- `.venv/bin/pytest`

------
https://chatgpt.com/codex/tasks/task_e_68af50691d4483278cc4240a86500d17