### PR TITLE
feat: enhance logging and error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## [0.0.10] - 2025-08-27
+
+### Added
+- add transport runtime error and command runner error types
+- log kitty operations with detailed context
+
+### Changed
+- standardize backend logging and diagnostics
+
 ## [0.0.9] - 2025-08-27
 
 ### Added

--- a/TODO.md
+++ b/TODO.md
@@ -44,19 +44,19 @@
 
 # logging
 
-* [ ] Add `logger.debug` calls at each fallback or gate decision point
-* [ ] Include `exc_info=True` in relevant log calls for backends
-* [ ] Standardize logger names and messaging conventions across the repo
-* [ ] In Kitty operations logs, include key fields: transport, timeout, bytes sent, image ID, etc.
+* [x] Add `logger.debug` calls at each fallback or gate decision point
+* [x] Include `exc_info=True` in relevant log calls for backends
+* [x] Standardize logger names and messaging conventions across the repo
+* [x] In Kitty operations logs, include key fields: transport, timeout, bytes sent, image ID, etc.
 
 # error messages
 
-* [ ] Audit exception messages across the codebase and assign each to a local variable before raising
+* [x] Audit exception messages across the codebase and assign each to a local variable before raising
 * [x] Define a `TransportInitError` exception
 * [x] Define a `TransportUnavailableError` exception
-* [ ] Define a `TransportRuntimeError` exception
-* [ ] Surface structured errors (custom exception types) from `CommandRunner`
-* [ ] Wrap entry-point loading in `try/except` and emit clear diagnostics on failure
+* [x] Define a `TransportRuntimeError` exception
+* [x] Surface structured errors (custom exception types) from `CommandRunner`
+* [x] Wrap entry-point loading in `try/except` and emit clear diagnostics on failure
 
 # code reorganization
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 # =================================== project ====================================
 [project]
   name = "wskr"
-  version = "0.0.9"
+  version = "0.0.10"
   description = ""
   readme = "README.md"
   authors = [

--- a/src/wskr/errors.py
+++ b/src/wskr/errors.py
@@ -17,3 +17,11 @@ class TransportUnavailableError(TransportError):
 
 class TransportInitError(TransportError):
     """Raised when a transport fails to initialise."""
+
+
+class TransportRuntimeError(TransportError):
+    """Raised when a transport operation fails at runtime."""
+
+
+class CommandRunnerError(RuntimeError):
+    """Raised when ``CommandRunner`` fails to execute a command."""

--- a/src/wskr/tty/kitty_parser.py
+++ b/src/wskr/tty/kitty_parser.py
@@ -6,6 +6,8 @@ import logging
 import re
 import sys
 
+from wskr.errors import TransportRuntimeError
+
 logger = logging.getLogger(__name__)
 
 
@@ -33,10 +35,10 @@ class KittyChunkParser:
         """Validate and extract the kitty image ID from ``resp``."""
         if not resp:
             msg = "No response from kitty on image init"
-            raise RuntimeError(msg)
+            raise TransportRuntimeError(msg)
         text = resp.decode("ascii")
         m = cls._RESP_RE.match(text)
         if not m or int(m.group(2)) != img_num:
             msg = f"Unexpected kitty response: {text!r}"
-            raise RuntimeError(msg)
+            raise TransportRuntimeError(msg)
         return int(m.group(1))

--- a/tests/test_mpl_iterm2.py
+++ b/tests/test_mpl_iterm2.py
@@ -11,7 +11,7 @@ def test_iterm2_import_raises(monkeypatch):
     sys.modules.pop("wskr.mpl.iterm2", None)
     with pytest.raises(
         FeatureUnavailableError,
-        match=r"iTerm2 backend is not yet implemented\. Set WSKR_ENABLE_ITERM2=true to bypass\."
+        match=r"iTerm2 backend is not yet implemented\. Set WSKR_ENABLE_ITERM2=true to bypass\.",
     ):
         import wskr.mpl.iterm2  # noqa: PLC0415
     orig_wskr_enable_iterm2 = os.environ.get("WSKR_ENABLE_ITERM2")

--- a/tests/test_tty_command_runner.py
+++ b/tests/test_tty_command_runner.py
@@ -2,6 +2,7 @@ import subprocess
 
 import pytest
 
+from wskr.errors import CommandRunnerError
 from wskr.tty.command import CommandRunner
 
 
@@ -50,5 +51,5 @@ def test_run_retry_exhausted(monkeypatch):
 
     monkeypatch.setattr(subprocess, "run", bad_run)
     runner = CommandRunner(retries=1)
-    with pytest.raises(subprocess.CalledProcessError):
+    with pytest.raises(CommandRunnerError):
         runner.run(["echo"])

--- a/tests/test_tty_registry.py
+++ b/tests/test_tty_registry.py
@@ -81,6 +81,19 @@ def test_entry_points_autoload(monkeypatch):
     configure(FALLBACK="noop")
 
 
+def test_entry_points_failure(monkeypatch):
+    configure(FALLBACK="noop")
+    monkeypatch.setattr(registry, "_ENTRYPOINTS_LOADED", False)
+
+    def bad_entry_points(*, group):
+        msg = "boom"
+        raise RuntimeError(msg)
+
+    monkeypatch.setattr(importlib.metadata, "entry_points", bad_entry_points)
+    # Should not raise despite entry point discovery failure
+    assert isinstance(get_image_transport("noop"), NoOpTransport)
+
+
 def test_get_image_transport_with_enum(monkeypatch):
     monkeypatch.setattr(
         registry,


### PR DESCRIPTION
## Summary
- add `TransportRuntimeError` and `CommandRunnerError`
- expand kitty transport logging and diagnostics
- surface structured command errors and improve entry-point loading

## Testing
- `.venv/bin/pytest tests/test_tty_command_runner.py tests/test_tty_kitty.py tests/test_tty_registry.py`
- `.venv/bin/pytest tests/test_transport_registry.py`
- `.venv/bin/pytest tests/test_e2e_kitty.py`
- `.venv/bin/pytest`


------
https://chatgpt.com/codex/tasks/task_e_68af59ee38888327a5d8f551a14d0aaf