### PR TITLE
refactor: split terminal I/O and OSC helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [0.0.16] - 2025-08-29
+
+### Changed
+- move terminal I/O helpers to `wskr.terminal.io` and OSC query helper to `wskr.terminal.osc`
+
 ## [0.0.15] - 2025-08-28
 
 ### Removed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 # =================================== project ====================================
 [project]
   name = "wskr"
-  version = "0.0.15"
+  version = "0.0.16"
   description = ""
   readme = "README.md"
   authors = [

--- a/src/wskr/protocol/kgp/kgp.py
+++ b/src/wskr/protocol/kgp/kgp.py
@@ -9,7 +9,7 @@ from wskr.protocol.kgp.parser import KittyChunkParser
 from wskr.terminal.core.base import ImageTransport
 from wskr.terminal.core.command import CommandRunner
 from wskr.terminal.core.registry import TransportName, register_image_transport
-from wskr.terminal.core.ttyools import query_tty
+from wskr.terminal.osc import query_tty
 
 logger = logging.getLogger(__name__)
 

--- a/src/wskr/render/matplotlib/utils.py
+++ b/src/wskr/render/matplotlib/utils.py
@@ -13,7 +13,7 @@ import re
 from typing import TYPE_CHECKING, Protocol
 
 from wskr.core.config import OSC_TIMEOUT_S
-from wskr.terminal.core.ttyools import query_tty
+from wskr.terminal.osc import query_tty
 
 try:
     import darkdetect  # type: ignore[import-not-found]

--- a/src/wskr/terminal/io.py
+++ b/src/wskr/terminal/io.py
@@ -168,6 +168,13 @@ def read_tty(
     return TTY_IO.read(timeout=timeout, min_bytes=min_bytes, more=more, echo=echo, fd=fd)
 
 
-def query_tty(request: bytes, more: MorePredicate, timeout: float | None = None) -> bytes:
-    """Send a request to the terminal and read the response."""
-    return TTY_IO.query(request, more, timeout)
+__all__ = [
+    "TTY_IO",
+    "MorePredicate",
+    "PosixTtyIO",
+    "TtyIO",
+    "lock_tty",
+    "read_tty",
+    "tty_attributes",
+    "write_tty",
+]

--- a/src/wskr/terminal/kitty/kitty_utils.py
+++ b/src/wskr/terminal/kitty/kitty_utils.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import re
 from typing import TYPE_CHECKING
 
-from wskr.terminal.core.ttyools import query_tty
+from wskr.terminal.osc import query_tty
 
 if TYPE_CHECKING:
     from collections.abc import Iterable

--- a/src/wskr/terminal/osc.py
+++ b/src/wskr/terminal/osc.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from .io import TTY_IO, MorePredicate
+
+
+def query_tty(request: bytes, more: MorePredicate, timeout: float | None = None) -> bytes:
+    """Send a request to the terminal and read the response."""
+    return TTY_IO.query(request, more, timeout)
+
+
+__all__ = ["query_tty"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,7 @@ import termios
 
 import pytest
 
-from wskr.terminal.core import ttyools
+from wskr.terminal import io
 from wskr.terminal.core.base import ImageTransport
 
 MAX_OUTPUT_LINES = 32
@@ -88,8 +88,8 @@ def fake_tty(monkeypatch, tmp_path):
     # 6) termios.tcdrain → no-op
     monkeypatch.setattr(termios, "tcdrain", lambda fd: None)
 
-    # 7) Replace ttyools.tty_attributes with a real no-op context manager
-    monkeypatch.setattr(ttyools, "tty_attributes", lambda *args, **kwargs: contextlib.nullcontext())
+    # 7) Replace io.tty_attributes with a real no-op context manager
+    monkeypatch.setattr(io, "tty_attributes", lambda *args, **kwargs: contextlib.nullcontext())
 
     # 8) select.select always reports no data
     monkeypatch.setattr(select, "select", lambda r, w, x, t: ([], [], []))

--- a/tests/test_dark_mode.py
+++ b/tests/test_dark_mode.py
@@ -6,7 +6,7 @@ import threading
 import pytest
 
 from wskr.render.matplotlib import utils
-from wskr.terminal.core import ttyools
+from wskr.terminal import io
 
 
 def test_env_color_strategy(monkeypatch):
@@ -71,7 +71,7 @@ def test_detect_dark_mode_chain(monkeypatch):
 
 def test_osc_strategy_real_tty(monkeypatch):
     master_fd, slave_fd = pty.openpty()
-    monkeypatch.setattr(ttyools, "_get_tty_fd", lambda: os.dup(slave_fd))
+    monkeypatch.setattr(io, "_get_tty_fd", lambda: os.dup(slave_fd))
 
     def responder():
         data = os.read(master_fd, 100)

--- a/tests/test_tty_extras.py
+++ b/tests/test_tty_extras.py
@@ -2,7 +2,7 @@ import contextlib
 import os
 import termios
 
-from wskr.terminal.core import ttyools
+from wskr.terminal import io, osc
 
 
 def test_tty_attributes_roundtrip(monkeypatch):
@@ -10,7 +10,7 @@ def test_tty_attributes_roundtrip(monkeypatch):
     calls = []
     monkeypatch.setattr(termios, "tcgetattr", lambda fd: fake_attr.copy())
     monkeypatch.setattr(termios, "tcsetattr", lambda fd, when, attr: calls.append(attr.copy()))
-    with ttyools.tty_attributes(1, min_bytes=1, echo=True):
+    with io.tty_attributes(1, min_bytes=1, echo=True):
         pass
     # two calls: set new attributes then restore original
     assert len(calls) == 2
@@ -21,42 +21,40 @@ def test_tty_attributes_roundtrip(monkeypatch):
 
 
 def test_read_tty_variants(monkeypatch):
-    monkeypatch.setattr(ttyools, "_get_tty_fd", lambda: 99)
+    monkeypatch.setattr(io, "_get_tty_fd", lambda: 99)
     monkeypatch.setattr(os, "close", lambda fd: None)
     monkeypatch.setattr(termios, "tcdrain", lambda fd: None)
-    monkeypatch.setattr(ttyools, "tty_attributes", lambda *a, **k: contextlib.nullcontext())
+    monkeypatch.setattr(io, "tty_attributes", lambda *a, **k: contextlib.nullcontext())
 
     # timeout None branch
     reads = [b"a", b"b", b""]
     monkeypatch.setattr(os, "read", lambda fd, n: reads.pop(0) if reads else b"")
     monkeypatch.setattr(
-        ttyools,
+        io,
         "select",
         lambda r, w, x, t: ([99], [], []) if reads else ([], [], []),
     )
-    assert ttyools.read_tty(timeout=None, min_bytes=0) == b"ab"
+    assert io.read_tty(timeout=None, min_bytes=0) == b"ab"
 
     # timeout with min_bytes branch
     reads2 = [b"X", b"Y"]
     monkeypatch.setattr(os, "read", lambda fd, n: b"Z" if n > 1 else (reads2.pop(0) if reads2 else b""))
     monkeypatch.setattr(
-        ttyools,
+        io,
         "select",
         lambda r, w, x, t: ([99], [], []) if reads2 else ([], [], []),
     )
-    out = ttyools.read_tty(timeout=0.1, min_bytes=2, more=lambda b: len(b) < 4)
+    out = io.read_tty(timeout=0.1, min_bytes=2, more=lambda b: len(b) < 4)
     assert out.startswith(b"Z")
 
 
 def test_query_tty(monkeypatch):
-    monkeypatch.setattr(ttyools, "_get_tty_fd", lambda: 55)
+    monkeypatch.setattr(io, "_get_tty_fd", lambda: 55)
     writes = []
     monkeypatch.setattr(os, "write", lambda fd, data: writes.append((fd, data)))
     monkeypatch.setattr(termios, "tcdrain", lambda fd: None)
     monkeypatch.setattr(os, "close", lambda fd: None)
-    monkeypatch.setattr(
-        ttyools.TTY_IO, "read", lambda *, fd=None, timeout=None, more=None, echo=False: b"resp"
-    )
-    resp = ttyools.query_tty(b"req", more=lambda b: True)
+    monkeypatch.setattr(io.TTY_IO, "read", lambda *, fd=None, timeout=None, more=None, echo=False: b"resp")
+    resp = osc.query_tty(b"req", more=lambda b: True)
     assert resp == b"resp"
     assert writes == [(55, b"req")]

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.12"
 
 [[package]]
@@ -1342,7 +1342,7 @@ wheels = [
 
 [[package]]
 name = "wskr"
-version = "0.0.14"
+version = "0.0.16"
 source = { editable = "." }
 dependencies = [
     { name = "darkdetect" },


### PR DESCRIPTION
## Summary
- move terminal I/O utilities into new `wskr.terminal.io` module
- expose OSC query helper as `wskr.terminal.osc.query_tty`
- update imports and tests for new layout

## Testing
- `.venv/bin/ruff format src/ tests/`
- `.venv/bin/ruff check src/ tests/`
- `.venv/bin/ty check src/ tests/`
- `.venv/bin/pytest`

------
https://chatgpt.com/codex/tasks/task_e_68afc1e43fe88327b754e6f2a132a29a